### PR TITLE
Add Quantum Able-inspired styling

### DIFF
--- a/static/css/quantum_able.css
+++ b/static/css/quantum_able.css
@@ -1,0 +1,41 @@
+@import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap');
+
+body {
+    font-family: 'Poppins', sans-serif;
+    background: #f4f6fb;
+}
+
+.navbar {
+    background: linear-gradient(90deg, #6a11cb, #2575fc);
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.navbar .navbar-brand,
+.navbar .nav-link {
+    color: #ffffff !important;
+}
+
+.navbar .nav-link:hover {
+    color: #f1f1f1 !important;
+}
+
+.btn-primary {
+    background: #6a11cb;
+    border-color: #6a11cb;
+}
+
+.btn-primary:hover {
+    background: #2575fc;
+    border-color: #2575fc;
+}
+
+.card {
+    border-radius: 0.5rem;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.05);
+    border: none;
+}
+
+.table thead th {
+    background: #e1e4f0;
+    color: #333;
+}

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -11,6 +11,7 @@
     <meta charset="UTF-8">
     <title>{{ _('WDT Air Cargo System') }}</title>
     <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/quantum_able.css') }}">
     <style>
         .flashes {
             list-style: none;
@@ -47,7 +48,7 @@
     </style>
 </head>
 <body>
-    <nav class="navbar navbar-expand-lg navbar-light bg-light">
+    <nav class="navbar navbar-expand-lg navbar-dark">
         <div class="container-fluid">
             <a class="navbar-brand" href="{{ url_for('dashboard.dashboard_home') }}">{{ _('WDT Air Cargo') }}</a>
             


### PR DESCRIPTION
## Summary
- apply Quantum Able-inspired design
- include new stylesheet
- use dark navbar to match gradient

## Testing
- `python app.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68576a0a86008329beffd6bdda868080